### PR TITLE
Add more configuration options

### DIFF
--- a/account.py
+++ b/account.py
@@ -1,6 +1,7 @@
 from swipe import Swipe
 from python_freeipa import ClientMeta
 import logging
+from config import Config
 
 ONE_USER_MATCHED = '1 user matched'
 
@@ -9,8 +10,9 @@ class Account():
     Representation of an IPA server account.
     """
 
-    def __init__(self, swipe: Swipe, client: ClientMeta, logger: logging.Logger) -> None:
+    def __init__(self, swipe: Swipe, client: ClientMeta, logger: logging.Logger, config: Config) -> None:
         self.logger = logger
+        self.config = config
         self.client = client
         self.user = client.user_find(o_employeenumber=swipe.id) # returns a dictionary with the user's info
         self.summary = self.get_summary()
@@ -48,8 +50,8 @@ class Account():
             # (if swiped lcc and 8 digit num are both empty, all users will be matched)
             return False
 
-        if 'users' not in self.groups:
-            # make sure the account is in the users group
+        if not (set(self.groups) & self.config.access.allowed_groups):
+            # account does not have any of the groups with access
             return False
         
         try:

--- a/config.example.cfg
+++ b/config.example.cfg
@@ -1,6 +1,14 @@
+[logging]
+log = /var/log/gatekeeper/debug.log
+
 [credentials]
-username = 
-password = 
+host = ipa.example.com
+verify_ssl = false
+username = gatekeep
+password = ga$1ight_g1rlb0$s
+
+[access]
+allowed_groups = users
 
 [strike]
 method = fake

--- a/config.py
+++ b/config.py
@@ -1,0 +1,87 @@
+from typing import Union
+import os
+import configparser
+import sys
+from dataclasses import dataclass
+
+@dataclass
+class Logging:
+    # path to log file
+    log: os.PathLike
+
+@dataclass
+class Credentials:
+    host: str
+    verify_ssl: bool
+    username: str
+    password: str
+
+    def __repr__(self):
+        # Custom repr to prevent accidentally printing the password
+        return f"Credentials(host={repr(self.host)}, verify_ssl={repr(self.verify_ssl)}, username={repr(self.username)}, password=*****)"
+
+@dataclass
+class Access:
+    # comma separated list of groups to grant access to
+    allowed_groups: set[str]
+
+@dataclass
+class Strike:
+    # Make sure to keep these two lists in sync
+    METHODS = ['fake', 'arduino', 'pi']
+    method: Union['fake', 'arduino', 'pi']
+
+@dataclass
+class Config:
+    logging: Logging
+    credentials: Credentials
+    access: Access
+    strike: Strike
+
+def load_config(config_path: os.PathLike) -> Config:
+    '''
+    Load and validate the config file. Exits the program if the config is invalid.
+    '''
+
+    # NOTE: This method logs directly to stderr instead of using the proper
+    # logger, because the logger is not available before the config is loaded.
+
+    try:
+        cfg = configparser.ConfigParser()
+        cfg.read(config_path)
+    except Exception as e:
+        print(f"Failed to load config file from {config_path}: {e}", file=sys.stderr)
+        exit(1)
+
+    try:
+        logging = Logging(log=cfg.get("logging", "log"))
+
+        credentials = Credentials(
+            host=cfg.get('credentials', 'host'),
+            verify_ssl=cfg.getboolean('credentials', 'verify_ssl'),
+            username=cfg.get('credentials', 'username'),
+            password=cfg.get('credentials', 'password')
+        )
+
+        access = Access(
+            allowed_groups=set(cfg.get('access', 'allowed_groups').split(','))
+        )
+
+        strike_method = cfg.get('strike', 'method')
+        if strike_method not in Strike.METHODS:
+            raise TypeError(f'Expected strike.method to be one of {Strike.METHODS}')
+        strike = Strike(
+            method=strike_method
+        )
+
+        config = Config(
+            logging=logging,
+            credentials=credentials,
+            access=access,
+            strike=strike
+        )
+    except Exception as e:
+        print(f"Error in config file {config_path}: {e}", file=sys.stderr)
+        exit(1)
+
+    return config

--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
 from swipe import Swipe
 from account import Account
-from strike import Strike, ArduinoStrike, RasPiStrike
+from strike import Strike, get_strike_for_method
 from utils import Utils
 from python_freeipa import ClientMeta
-import configparser
+from config import load_config, Config
 import signal
 import urllib3
 import logging
@@ -11,76 +11,57 @@ import argparse
 import os
 
 SCRIPT_PATH = os.path.abspath(os.path.dirname(__file__))
-PATH_TO_CFG = os.path.join(SCRIPT_PATH, "config.cfg")
+DEFAULT_CFG_PATH = os.path.join(SCRIPT_PATH, "config.cfg")
 EXIT_TOKENS = ['q', 'exit', 'quit']
-
-logger: logging.Logger = Utils.setup_custom_logger(__name__)
+LOGGER_NAME = 'lab_swipe'
 
 urllib3.disable_warnings()
 
 def signal_handler(sig, frame):
-    Utils.exit(logger, msg = "Exiting due to CTRL-C...")
+    Utils.exit(logging.getLogger(LOGGER_NAME), msg = "Exiting due to CTRL-C...")
 
 signal.signal(signal.SIGINT, signal_handler)
 
-def parse_args() -> Strike:
-    parser = argparse.ArgumentParser(description="GateKeeper program for the Computer Interest Floor Lab's door strike.")
-    parser.add_argument('--strike', '-s', help='Method used for striking the door. Fake is used for testing purposes.', choices=['fake', 'arduino', 'pi'], default=None)
+def main():
+    parser = argparse.ArgumentParser(description="GateKeeper program for controlling an electronic door strike with a card reader.")
+    parser.add_argument('--strike', '-s', help='Method used for controlling the door strike. Fake is used for testing purposes.', choices=['fake', 'arduino', 'pi'], default=None)
+    parser.add_argument('--config', '-c', help='Path to GateKeeper config file.', default=DEFAULT_CFG_PATH)
 
     args = parser.parse_args()
 
+    path_to_cfg = args.config
+    config: Config = load_config(path_to_cfg)
+
+    logger: logging.Logger = Utils.setup_custom_logger(LOGGER_NAME, log_file=config.logging.log)
+    logger.info(f"Loaded configuration from {path_to_cfg}: {repr(config)}")
+
+    strike_method = config.strike.method
     if args.strike:
-        method = args.strike
-    else:
-        try:
-            config = configparser.ConfigParser()
-            config.read(PATH_TO_CFG)
-            method = config.get('strike', 'method')
-        except Exception as e:
-            logger.exception(f"Something is wrong with the config file: {e}")
-            logger.warning("Setting output method to \"fake\"...")
-            method = 'fake'
-    
-    if method == 'fake':
-        strike = Strike(logger)
-    elif method == 'arduino':
-        strike = ArduinoStrike(logger)
-    elif method == 'pi':
-        strike = RasPiStrike(logger)
-
-    return strike
-
-def main():
-    strike = parse_args()
+        strike_method = args.strike
+    strike = get_strike_for_method(strike_method, logger)
 
     try:
-        config = configparser.ConfigParser()
-        config.read(PATH_TO_CFG)
-        username = config.get('credentials', 'username')
-        password = config.get('credentials', 'password')
+        client = ClientMeta(config.credentials.host, verify_ssl=config.credentials.verify_ssl)
+        client.login(config.credentials.username, config.credentials.password)
+        logger.info(f"Successfuly logged in to IPA at {config.credentials.host} as: {config.credentials.username}")
     except Exception as e:
-        logger.exception(f"Something is wrong with the config file: {e}")
-        Utils.exit(logger, msg = "Forcing exit...")
-
-    try:
-        client = ClientMeta('citadel.cif.rochester.edu', verify_ssl=False)
-        client.login(username, password)
-        logger.info(f"Successfuly logged in to Citadel IPA as: {username}")
-    except Exception as e:
-        logger.critical("Unable to connect to Citadel IPA server. Check credentials.")
+        logger.critical(f"Unable to connect to IPA server at {config.credentials.host}. Check credentials.")
         Utils.exit(logger, msg = "Forcing exit...")
     
     while(True):
-        data_from_swipe = input()
         # card reader acts as keyboard, so input() is
         # used to get the output of the card reader
+        try:
+            data_from_swipe = input()
+        except EOFError:
+            break
 
         if data_from_swipe.lower() in EXIT_TOKENS:
             break
 
         swipe = Swipe(data_from_swipe, logger)
 
-        account = Account(swipe, client, logger)
+        account = Account(swipe, client, logger, config)
 
         try:
             if account.has_access:

--- a/main.py
+++ b/main.py
@@ -49,8 +49,8 @@ def main():
         Utils.exit(logger, msg = "Forcing exit...")
     
     while(True):
-        # card reader acts as keyboard, so input() is
-        # used to get the output of the card reader
+        # card reader acts as keyboard, so input() is used to get the output of
+        # the card reader
         try:
             data_from_swipe = input()
         except EOFError:
@@ -75,4 +75,16 @@ def main():
     Utils.exit(logger)
 
 if __name__ == "__main__":
-    main()
+    # Catch any exceptions that bubble up all the way through `main` to make
+    # sure the exception gets logged properly.
+    try:
+        main()
+    except Exception as e:
+        logger = logging.getLogger(LOGGER_NAME)
+        if logger is None:
+            # Unhandled exception was raised before logger could be created, so
+            # we can't do anything better than just letting Python crash.
+            raise e
+
+        logger.critical('Unexpected exception. Crashing...', exc_info=e)
+        exit(1)

--- a/strike.py
+++ b/strike.py
@@ -1,9 +1,9 @@
+from typing import Union
 from utils import Utils
 import serial
 import logging
 import time
 import serial.tools.list_ports
-import RPi.GPIO as GPIO
 
 class Strike():
     """
@@ -27,6 +27,7 @@ class RasPiStrike(Strike):
     """
     
     def __init__(self, logger: logging.Logger) -> None:
+        import RPi.GPIO as GPIO
         self.logger = logger
         GPIO.setmode(GPIO.Board)
         GPIO.setup(self.channel,GPIO.OUT)
@@ -84,6 +85,16 @@ class ArduinoStrike(Strike):
                 self.logger.error(f"Error striking: {str(e)}")
         else:
             self.logger.warning("Strike not sent; Arduino not available.")
+
+def get_strike_for_method(method: Union['fake', 'arduino', 'pi'], logger: logging.Logger) -> Strike:
+    if method == 'fake':
+        return Strike(logger)
+    elif method == 'arduino':
+        return ArduinoStrike(logger)
+    elif method == 'pi':
+        return RasPiStrike(logger)
+    else:
+        raise TypeError(f'Expected method to be one of fake, arduino, pi, but got `{method}`')
 
 def main():
     # Testing

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,7 @@
 import logging
-import sys, os
-
-SCRIPT_PATH = os.path.abspath(os.path.dirname(__file__))
+import sys
+import os
+import pathlib
 
 class Utils():
     """
@@ -11,14 +11,17 @@ class Utils():
     def __init__(self) -> None:
         pass
 
-    def setup_custom_logger(name, file: str=os.path.join(SCRIPT_PATH, 'logs', 'labswipe.log')) -> logging.Logger:
+    def setup_custom_logger(name: str, log_file: str) -> logging.Logger:
         """
         Function to return a Logger with all the previously specified options.
         """
 
+        # Ensure directory containing the log_file exists
+        pathlib.Path(log_file).parent.mkdir(parents=True, exist_ok=True)
+
         formatter = logging.Formatter(fmt='[%(asctime)s] %(levelname)-8s %(message)s',
                                     datefmt='%Y-%m-%d %H:%M:%S')
-        handler = logging.FileHandler(file, mode='a')
+        handler = logging.FileHandler(log_file, mode='a')
         handler.setFormatter(formatter)
         screen_handler = logging.StreamHandler(stream=sys.stdout)
         screen_handler.setFormatter(formatter)


### PR DESCRIPTION
Adds configuration for:
- Log file
- IPA host address
- Groups to give door access to

Refactors arg parsing code, and adds a new CLI arg for the config file (defaulting to `config.cfg`).

Updates `config.example.cfg` to show all of the new config options.

Adds a top-level exception handler in `main.py` to make sure uncaught exceptions get logged in the proper place.

**Untested:** Importing GPIO at the top-level in `strike.py` prevents testing of the software on hardware that isn't a Raspberry Pi. I moved the import into the `RaspPiStrike` constructor, but I haven't tested if that works properly.