### PR TITLE
Catch errors while fetching user accounts

### DIFF
--- a/main.py
+++ b/main.py
@@ -64,6 +64,9 @@ def main():
         try:
             account = Account(swipe, client, logger, config)
         except Exception as e:
+            # Note: This may log errors from python-freeipa. Inspecting the
+            # library source shows this will note leak any credentials into the
+            # log: https://github.com/waldur/python-freeipa/blob/develop/src/python_freeipa/exceptions.py
             logger.warning(f"Unable to instantiate account from ID: {swipe.id}, LCC: {swipe.lcc}", exc_info=e)
 
         if account.has_access:

--- a/main.py
+++ b/main.py
@@ -63,8 +63,8 @@ def main():
 
         try:
             account = Account(swipe, client, logger, config)
-        except:
-            logger.warning(f"Unable to insantiate account from ID: {swipe.id}, LCC: {swipe.lcc}")
+        except Exception as e:
+            logger.warning(f"Unable to instantiate account from ID: {swipe.id}, LCC: {swipe.lcc}", exc_info=e)
 
         if account.has_access:
             logger.info(f"Access granted to {account.netid}")

--- a/main.py
+++ b/main.py
@@ -61,16 +61,16 @@ def main():
 
         swipe = Swipe(data_from_swipe, logger)
 
-        account = Account(swipe, client, logger, config)
-
         try:
-            if account.has_access:
-                logger.info(f"Access granted to {account.netid}")
-                strike.strike()
-            else:
-                logger.info(f"Denied access to ID: {swipe.id} LCC: {swipe.lcc}")
+            account = Account(swipe, client, logger, config)
         except:
             logger.warning(f"Unable to insantiate account from ID: {swipe.id}, LCC: {swipe.lcc}")
+
+        if account.has_access:
+            logger.info(f"Access granted to {account.netid}")
+            strike.strike()
+        else:
+            logger.info(f"Denied access to ID: {swipe.id} LCC: {swipe.lcc}")
 
     Utils.exit(logger)
 


### PR DESCRIPTION
A try/except block was around the access of the field `account.has_access`, which can't throw any errors. It should've been around the creation of the `account` variable (that's where the calls to `python_freeipa` happen), so I've moved it there.

I also added the exception to the log statement that gets printed. See the code for a note about security (TL;DR it's fine).

p.s. please "Squash and Rebase" when you merge