### PR TITLE
implement ipa restart when account initialization fails

### DIFF
--- a/account.py
+++ b/account.py
@@ -13,7 +13,9 @@ class Account():
         self.logger = logger
         self.config = config
         self.client = client
+
         self.user = client.user_find(o_employeenumber=id) # returns a dictionary with the user's info
+        
         self.summary = self.get_summary()
         self.swiped_lcc = lcc
         self.id = id
@@ -47,7 +49,7 @@ class Account():
         
         if self.summary != ONE_USER_MATCHED:
             # make sure that there is only one user being matched
-            # (if swiped lcc and 8 digit num are both empty, all users will be matched)
+            # (if swiped lcc and 8 digit id are both empty, all users will be matched)
             return False
 
         if not (set(self.groups) & self.config.access.allowed_groups):
@@ -79,7 +81,7 @@ class Account():
     
     def update_LCC(self) -> None:
         """
-        Updates the LCC of the user to the LCC thatwas swiped.
+        Updates the LCC of the user to the LCC that was swiped.
         """
         
         self.client.user_mod(a_uid=self.netid, o_employeetype=self.swiped_lcc)

--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ def main():
     reader = cardreader.get_cardreader(config.reader, logger)
     for evt in reader.events():
         if isinstance(evt, cardreader.SwipeEvent):
-            account = None
+            account: Account = None
             id = evt.id
             lcc = evt.lcc
 

--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ def main():
     reader = cardreader.get_cardreader(config.reader, logger)
     for evt in reader.events():
         if isinstance(evt, cardreader.SwipeEvent):
+            account = None
             id = evt.id
             lcc = evt.lcc
 
@@ -58,12 +59,11 @@ def main():
 
                 account = Utils.get_account_from_ipa(id, lcc, logger, client, config)
 
-            if account:
-                if account.has_access:
-                    logger.info(f"Access granted to {account.netid}")
-                    strike.strike()
-                else:
-                    logger.info(f"Denied access to ID: {id} LCC: {lcc}")
+            if account and account.has_access:
+                logger.info(f"Access granted to {account.netid}")
+                strike.strike()
+            else:
+                logger.info(f"Denied access to ID: {id} LCC: {lcc}")
         elif isinstance(evt, cardreader.InvalidDataEvent):
             logger.warning(f"Invalid data received from card reader: {evt.data}", exc_info=evt.exc_info)
         else:

--- a/strike.py
+++ b/strike.py
@@ -37,7 +37,7 @@ class RasPiStrike(Strike):
         """
         Implementation of striking the door using the Raspberry Pi's pins.
         """
-        self.logger.info("RasPi Striking!")
+        #self.logger.info("RasPi Striking!")
         self.GPIO.output(self.channel,self.GPIO.HIGH)
         time.sleep(5.0)
         self.GPIO.output(self.channel,self.GPIO.LOW)

--- a/strike.py
+++ b/strike.py
@@ -33,7 +33,6 @@ class RasPiStrike(Strike):
         GPIO.setmode(GPIO.BOARD)
         GPIO.setup(self.channel,GPIO.OUT)
         
-    
     def strike(self):
         """
         Implementation of striking the door using the Raspberry Pi's pins.
@@ -101,7 +100,7 @@ def get_strike_for_method(method: Union['fake', 'arduino', 'pi'], logger: loggin
 def main():
     # Testing
     logger = Utils.setup_custom_logger(__name__)
-    strike_controller = ArduinoStrike(logger)
+    strike_controller = Strike(logger)
     strike_controller.strike()
 
 if __name__ == "__main__":

--- a/utils.py
+++ b/utils.py
@@ -67,7 +67,7 @@ class Utils():
         return client
 
     def get_account_from_ipa(id: str, lcc: str, logger: logging.Logger, client: ClientMeta, config: Config) -> Account:
-        account = None
+        account: Account = None
 
         try:
             account = Account(id, lcc, client, logger, config)


### PR DESCRIPTION
created `get_account_from_ipa` and `setup_ipa_client` function in utils.py.

`get_account_from_ipa` will return `None` if the account was not created. this means that id cards without proper access to the lab will not unlock the door.

if the account is in fact `None`, that will most likely mean that the IPA session was timed out. Therefore, in the main loop, if account is `None`, it will now restart the connection to IPA and try to instantiate the account one more time.